### PR TITLE
Update selectFx.js

### DIFF
--- a/js/selectFx.js
+++ b/js/selectFx.js
@@ -75,7 +75,7 @@ function factory(classie) {
 		// when opening the select element, the default placeholder (if any) is shown
 		stickyPlaceholder : true,
 		// callback when changing the value
-		onChange : function( val ) { return false; }
+		onChange : function( val, el, that ) { return false; }
 	};
 
 	/**
@@ -328,7 +328,7 @@ function factory(classie) {
 		}
 
 		// callback
-		this.options.onChange( this.el.value );
+		this.options.onChange( this.el.value, this.el, this );
 	};
 
 	/**


### PR DESCRIPTION
Hi, 
there are use cases where you need more information on the changed event. I'm using for example a WooCommerce Plugin with ugly select elements but which uses custom onchange  jQuery functions with conditional logic. This functions only work on jQuery(el).trigger("change"). So I have to call this trigger function manually on SelectFx.onChange() and provide the select element which has changed. 